### PR TITLE
Update to criterion 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ bincode = { version = "1.3.3" }
 
 [dev-dependencies]
 hex = "0.3"
-criterion = "0.3"
+criterion = "0.5"
 bincode = "1"
 rand_chacha = "0.2"
 

--- a/benches/generators.rs
+++ b/benches/generators.rs
@@ -1,19 +1,20 @@
 use bulletproofs::{BulletproofGens, PedersenGens};
-
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
+use criterion::BenchmarkId;
+use criterion::{Criterion, criterion_main, criterion_group};
 
 fn pc_gens(c: &mut Criterion) {
     c.bench_function("PedersenGens::new", |b| b.iter(|| PedersenGens::default()));
 }
 
 fn bp_gens(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "BulletproofGens::new",
-        |b, size| b.iter(|| BulletproofGens::new(*size, 1)),
-        (0..10).map(|i| 2 << i),
-    );
+    let mut group = c.benchmark_group("BulletproofGens::new");
+    for size in (0..10).map(|i| 2 << i) {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &size,
+            |b, &size| b.iter(|| BulletproofGens::new(size, 1)),
+        );
+    }
 }
 
 criterion_group! {

--- a/benches/linear_proof.rs
+++ b/benches/linear_proof.rs
@@ -1,13 +1,7 @@
 #![allow(non_snake_case)]
 
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
-
-extern crate bulletproofs;
-extern crate curve25519_dalek;
-extern crate merlin;
-extern crate rand;
+use criterion::BenchmarkId;
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use core::iter;
 
@@ -22,8 +16,11 @@ use merlin::Transcript;
 static TEST_SIZES: [usize; 5] = [64, 128, 256, 512, 1024];
 
 fn create_linear_proof_helper(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "linear proof creation",
+    let mut group = c.benchmark_group("linear proof creation");
+    for size in TEST_SIZES {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &size,
         move |bench, n| {
             let mut rng = rand::thread_rng();
 
@@ -68,8 +65,8 @@ fn create_linear_proof_helper(c: &mut Criterion) {
                 .unwrap();
             })
         },
-        TEST_SIZES,
-    );
+        );
+    }
 }
 
 /// Copied from src/inner_product_proof.rs
@@ -99,8 +96,11 @@ criterion_group! {
 }
 
 fn linear_verify(c: &mut Criterion) {
-    c.bench_function_over_inputs(
-        "linear proof verification",
+    let mut group = c.benchmark_group("linear proof verification");
+    for size in TEST_SIZES {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &size,
         move |bench, n| {
             let bp_gens = BulletproofGens::new(*n, 1);
             let mut rng = rand::thread_rng();
@@ -156,8 +156,8 @@ fn linear_verify(c: &mut Criterion) {
                     .unwrap();
             });
         },
-        TEST_SIZES,
-    );
+        );
+    }
 }
 
 criterion_group! {

--- a/benches/r1cs.rs
+++ b/benches/r1cs.rs
@@ -1,8 +1,6 @@
 #![allow(non_snake_case)]
 
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
+use criterion::{Criterion, criterion_group, criterion_main};
 
 // Code below copied from ../tests/r1cs.rs
 //

--- a/benches/range_proof.rs
+++ b/benches/range_proof.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
+use criterion::BenchmarkId;
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use rand;
 use rand::Rng;
@@ -17,10 +16,13 @@ static AGGREGATION_SIZES: [usize; 6] = [1, 2, 4, 8, 16, 32];
 
 fn create_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
     let label = format!("Aggregated {}-bit rangeproof creation", n);
+    let mut group = c.benchmark_group(&label);
 
-    c.bench_function_over_inputs(
-        &label,
-        move |b, &&m| {
+    for size in AGGREGATION_SIZES {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &size,
+        move |b, &m| {
             let pc_gens = PedersenGens::default();
             let bp_gens = BulletproofGens::new(n, m);
             let mut rng = rand::thread_rng();
@@ -43,8 +45,8 @@ fn create_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
                 )
             })
         },
-        &AGGREGATION_SIZES,
-    );
+        );
+    }
 }
 
 fn create_aggregated_rangeproof_n_8(c: &mut Criterion) {
@@ -65,10 +67,13 @@ fn create_aggregated_rangeproof_n_64(c: &mut Criterion) {
 
 fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
     let label = format!("Aggregated {}-bit rangeproof verification", n);
+    let mut group = c.benchmark_group(&label);
 
-    c.bench_function_over_inputs(
-        &label,
-        move |b, &&m| {
+    for size in AGGREGATION_SIZES {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &size,
+        move |b, &m| {
             let pc_gens = PedersenGens::default();
             let bp_gens = BulletproofGens::new(n, m);
             let mut rng = rand::thread_rng();
@@ -95,8 +100,8 @@ fn verify_aggregated_rangeproof_helper(n: usize, c: &mut Criterion) {
                 proof.verify_multiple(&bp_gens, &pc_gens, &mut transcript, &value_commitments, n)
             });
         },
-        &AGGREGATION_SIZES,
-    );
+        );
+    }
 }
 
 fn verify_aggregated_rangeproof_n_8(c: &mut Criterion) {


### PR DESCRIPTION
Port to the current release of the `criterion` benchmark harness to address `cargo audit` warnings about transitive dependencies. The `benchmark_function_with_inputs` API has been deprecated since 0.3 and is removed in 0.4 and most benchmarks must therefore be ported to the new `BenchmarkGroup` type.